### PR TITLE
修复某些bug以及提交两个关于标签的新增特性！

### DIFF
--- a/module/page.ftl
+++ b/module/page.ftl
@@ -4,12 +4,12 @@
 <!-- Page Header -->
 <#if is_sheet!false>
     <#if post.thumbnail?length gt 0>
-        <header class="intro-header" style="background-image: url(${cover})">
+        <header class="intro-header" style="background-image: url('${cover}')">
     <#else>
-        <header class="intro-header" style="background-image: url(${post.thumbnail})">
+        <header class="intro-header" style="background-image: url('${post.thumbnail}')">
     </#if>
 <#else>
-    <header class="intro-header" style="background-image: url(${cover})">
+    <header class="intro-header" style="background-image: url('${cover}')">
 </#if>
     <div class="container">
         <div class="row">

--- a/module/page.ftl
+++ b/module/page.ftl
@@ -193,7 +193,7 @@
                         <@linkTag method="list">
                             <#if links?? && links?size gt 0>
                                 <#list links as link>
-                                <li><a href="${link.url}">${link.name}</a></li>
+                                <li><a href="${link.url}" target="_blank" title="${link.description}">${link.name}</a></li>
                                 </#list>
                             </#if>
                         </@linkTag>

--- a/post.ftl
+++ b/post.ftl
@@ -133,7 +133,7 @@
                         <@linkTag method="list">
                             <#if links?? && links?size gt 0>
                                 <#list links as link>
-                                    <li><a href="${link.url}">${link.name}</a></li>
+                                    <li><a href="${link.url}"  target="_blank" title="${link.description}">${link.name}</a></li>
                                 </#list>
                             </#if>
                         </@linkTag>

--- a/source/js/archive.js
+++ b/source/js/archive.js
@@ -133,6 +133,7 @@ https://github.com/kitian616/jekyll-TeXt-theme
         _tag = query.tag;
 
     init(); 
+    _tag = decodeURI(_tag);
     tagSelect(_tag);
 
     $tags.on('click', 'a', function() {   /* only change */


### PR DESCRIPTION
1、修复：修复从文章页点击中文标签后，无法匹配到对应标签的问题；
2、修复：修复头部背景图片可能无法展示的问题；
3、新增特性：当鼠标悬停在友链上时，展示该友链的描述；
4、新增特性：点击友链的方式为新建一个标签页打开。

共两个bug修复，和两个新增特性