### PR TITLE
Update archive.js  修复直接进入标签页，不带任何标签时，无法展示所有标签

### DIFF
--- a/source/js/archive.js
+++ b/source/js/archive.js
@@ -133,7 +133,7 @@ https://github.com/kitian616/jekyll-TeXt-theme
         _tag = query.tag;
 
     init(); 
-    _tag = decodeURI(_tag);
+    if(_tag) _tag = decodeURI(_tag);
     tagSelect(_tag);
 
     $tags.on('click', 'a', function() {   /* only change */


### PR DESCRIPTION
fixbug：直接进入标签页，不带任何标签时，无法展示所有标签